### PR TITLE
add autocomplete for yaml and dockercompose

### DIFF
--- a/lib/autocompletion.js
+++ b/lib/autocompletion.js
@@ -19,6 +19,8 @@ const run = function (context) {
   const dart = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'dart' }, providers.dartCompletion, '(')
   const kotlin = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'kotlin' }, providers.kotlinCompletion, '(')
   const elixir = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'elixir' }, providers.elixirCompletion, '(')
+  const dockercompose = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'dockercompose' }, providers.yamlCompletion, '$')
+  const yaml = vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: 'yaml' }, providers.yamlCompletion, '$')
 
   context.subscriptions.push(javascript)
   context.subscriptions.push(typescript)
@@ -37,6 +39,8 @@ const run = function (context) {
   context.subscriptions.push(dart)
   context.subscriptions.push(kotlin)
   context.subscriptions.push(elixir)
+  context.subscriptions.push(dockercompose)
+  context.subscriptions.push(yaml)
   return true
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,7 +39,8 @@ function hover (language, document, position) {
     rust: /std::env::(?:var|var_os)\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
     dart: /String.fromEnvironment\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
     kotlin: /System.getenv\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
-    elixir: /System.get_env\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/
+    elixir: /System.get_env\(["']([A-Z]{1}[A-Z_0123456789]+)["']\)/,
+    yaml: /\$([a-zA-Z_0123456789]+)/
   }
   const reg = regexDict[language]
   const line = document.lineAt(position).text
@@ -65,7 +66,7 @@ function hover (language, document, position) {
 
 function autocomplete (triggerCharacter, document, position) {
   const entries = envEntries()
-  const quote = triggerCharacter === '.' ? '' : '"' // for javascript, doesn't use quotation in env reference so make sure not to add to insert/filter text
+  const quote = triggerCharacter === '.' || triggerCharacter === "$" ? '' : '"' // for javascript or yaml, doesn't use quotation in env reference so make sure not to add to insert/filter text
   return entries.map(function (env) {
     const key = env[0].trim()
     const value = env[1].trim()

--- a/lib/peeking.js
+++ b/lib/peeking.js
@@ -17,6 +17,8 @@ const run = function (context) {
   const dartHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'dart' }, providers.dartHover)
   const kotlinHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'kotlin' }, providers.kotlinHover)
   const elixirHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'elixir' }, providers.elixirHover)
+  const dockercomposeHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'dockercompose' }, providers.yamlHover)
+  const yamlHover = vscode.languages.registerHoverProvider({ scheme: 'file', language: 'yaml' }, providers.yamlHover)
 
   context.subscriptions.push(javascriptHover)
   context.subscriptions.push(typescriptHover)
@@ -33,6 +35,8 @@ const run = function (context) {
   context.subscriptions.push(dartHover)
   context.subscriptions.push(kotlinHover)
   context.subscriptions.push(elixirHover)
+  context.subscriptions.push(dockercomposeHover);
+  context.subscriptions.push(yamlHover);
   return true
 }
 

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -68,6 +68,12 @@ const elixirHover = {
   }
 }
 
+const yamlHover = {
+  provideHover: function (document, position, token) {
+    return helpers.hover('yaml', document, position)
+  }
+}
+
 const javascriptCompletion = {
   provideCompletionItems: function (document, position) {
     const linePrefix = document.lineAt(position).text.slice(0, position.character)
@@ -211,6 +217,17 @@ const elixirCompletion = {
   }
 }
 
+const yamlCompletion = {
+  provideCompletionItems: function (document, position) {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character)
+    if (!linePrefix.endsWith('$')) {
+      return undefined
+    }
+
+    return helpers.autocomplete('$', document, position)
+  }
+}
+
 const viewDotenvNew = {
   refresh: function () {
     return null
@@ -238,6 +255,7 @@ module.exports.rustHover = rustHover
 module.exports.dartHover = dartHover
 module.exports.kotlinHover = kotlinHover
 module.exports.elixirHover = elixirHover
+module.exports.yamlHover = yamlHover
 module.exports.javascriptCompletion = javascriptCompletion
 module.exports.rubyCompletion = rubyCompletion
 module.exports.pythonCompletion = pythonCompletion
@@ -251,4 +269,5 @@ module.exports.rustCompletion = rustCompletion
 module.exports.dartCompletion = dartCompletion
 module.exports.kotlinCompletion = kotlinCompletion
 module.exports.elixirCompletion = elixirCompletion
+module.exports.yamlCompletion = yamlCompletion
 module.exports.viewDotenvNew = viewDotenvNew

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dotenv-vscode",
+  "name": "dotenv-vscode-stripped",
   "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dotenv-vscode",
+      "name": "dotenv-vscode-stripped",
       "version": "0.24.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Hey! I came accross this extension and its awesome :)

I added a new file handler for my use case (dockercompose and yaml)

I figured I will open the PR for these changes so I can get this newer version directly from the extension store (merge and publish changes)

Also I noticed that you don't accept issues on the repo, I had another idea for a feature request I may take a stab at myself. The other thing I wanted as a nice to have is get dotenv file comments to appear in the autocomplete box!